### PR TITLE
2種類の方法で位置情報を取得できるように実装

### DIFF
--- a/bang.xcodeproj/project.pbxproj
+++ b/bang.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6A604A32C528F8BB43AD4344 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 56E4A22E13D9ADD016D461F6 /* libPods.a */; };
+		B807F3361AB433D300571ACB /* Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B807F3351AB433D300571ACB /* Tracker.swift */; };
 		B82448401A8EF07700B540A4 /* Login.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B824483F1A8EF07700B540A4 /* Login.storyboard */; };
 		B82448421A8EF16C00B540A4 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82448411A8EF16C00B540A4 /* LoginViewController.swift */; };
 		B82448441A8F183400B540A4 /* FacebookManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82448431A8F183400B540A4 /* FacebookManager.swift */; };
@@ -52,6 +53,7 @@
 		07720D1FE88AFACC32454227 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		56E4A22E13D9ADD016D461F6 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9E24BFC2BD3FDB4B7751D942 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		B807F3351AB433D300571ACB /* Tracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tracker.swift; sourceTree = "<group>"; };
 		B824483F1A8EF07700B540A4 /* Login.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Login.storyboard; sourceTree = "<group>"; };
 		B82448411A8EF16C00B540A4 /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		B82448431A8F183400B540A4 /* FacebookManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FacebookManager.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 			children = (
 				B8D9B2541A8250F100B30271 /* Extensions */,
 				B8D9B2571A82529B00B30271 /* Vendors */,
+				B807F3351AB433D300571ACB /* Tracker.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -449,6 +452,7 @@
 				B8DD298A1A8B154E0024ABD0 /* BLEConfig.swift in Sources */,
 				B830CDDA1A82403B0038CAFE /* SearchViewController.swift in Sources */,
 				B8FDC5131A818EDC00D4511E /* AppDelegate.swift in Sources */,
+				B807F3361AB433D300571ACB /* Tracker.swift in Sources */,
 				B8F1389C1A8A4B84002A820E /* BLEPeripheralManager.swift in Sources */,
 				B8D9B2501A824DC700B30271 /* BaseViewController.swift in Sources */,
 				B8DD298C1A8B1CC10024ABD0 /* BLEEnumExtension.swift in Sources */,

--- a/bang.xcodeproj/project.pbxproj
+++ b/bang.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		B8DD298C1A8B1CC10024ABD0 /* BLEEnumExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DD298B1A8B1CC10024ABD0 /* BLEEnumExtension.swift */; };
 		B8E6D9A71ABE46B00094D582 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8E6D9A61ABE46B00094D582 /* CoreLocation.framework */; };
 		B8E6D9A91ABE55840094D582 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E6D9A81ABE55840094D582 /* LocationManager.swift */; };
+		B8E6D9AB1ABF03E70094D582 /* LocationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E6D9AA1ABF03E70094D582 /* LocationConfig.swift */; };
 		B8EA20FA1A99D35E00BD0164 /* Contact.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B8EA20F91A99D35E00BD0164 /* Contact.storyboard */; };
 		B8EA20FC1A99D37700BD0164 /* ContactViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EA20FB1A99D37700BD0164 /* ContactViewController.swift */; };
 		B8F1389C1A8A4B84002A820E /* BLEPeripheralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F1389B1A8A4B84002A820E /* BLEPeripheralManager.swift */; };
@@ -83,6 +84,7 @@
 		B8DD298B1A8B1CC10024ABD0 /* BLEEnumExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BLEEnumExtension.swift; sourceTree = "<group>"; };
 		B8E6D9A61ABE46B00094D582 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		B8E6D9A81ABE55840094D582 /* LocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		B8E6D9AA1ABF03E70094D582 /* LocationConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationConfig.swift; sourceTree = "<group>"; };
 		B8EA20F91A99D35E00BD0164 /* Contact.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Contact.storyboard; sourceTree = "<group>"; };
 		B8EA20FB1A99D37700BD0164 /* ContactViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactViewController.swift; sourceTree = "<group>"; };
 		B8F1389B1A8A4B84002A820E /* BLEPeripheralManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BLEPeripheralManager.swift; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 				B8DD29891A8B154E0024ABD0 /* BLEConfig.swift */,
 				B82448451A8F1E4700B540A4 /* FacebookConfig.swift */,
 				B82448471A903DE400B540A4 /* NotificationConfig.swift */,
+				B8E6D9AA1ABF03E70094D582 /* LocationConfig.swift */,
 			);
 			path = Configs;
 			sourceTree = "<group>";
@@ -469,6 +472,7 @@
 				B8D9B2501A824DC700B30271 /* BaseViewController.swift in Sources */,
 				B8DD298C1A8B1CC10024ABD0 /* BLEEnumExtension.swift in Sources */,
 				B82448441A8F183400B540A4 /* FacebookManager.swift in Sources */,
+				B8E6D9AB1ABF03E70094D582 /* LocationConfig.swift in Sources */,
 				B8D9B25D1A8254C400B30271 /* UIImageExtension.swift in Sources */,
 				B82448421A8EF16C00B540A4 /* LoginViewController.swift in Sources */,
 				B82448461A8F1E4700B540A4 /* FacebookConfig.swift in Sources */,

--- a/bang.xcodeproj/project.pbxproj
+++ b/bang.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		6A604A32C528F8BB43AD4344 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 56E4A22E13D9ADD016D461F6 /* libPods.a */; };
 		B807F3361AB433D300571ACB /* Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B807F3351AB433D300571ACB /* Tracker.swift */; };
+		B80D21151ABC5BEC00405EAE /* QueueManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80D21141ABC5BEC00405EAE /* QueueManager.swift */; };
 		B82448401A8EF07700B540A4 /* Login.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B824483F1A8EF07700B540A4 /* Login.storyboard */; };
 		B82448421A8EF16C00B540A4 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82448411A8EF16C00B540A4 /* LoginViewController.swift */; };
 		B82448441A8F183400B540A4 /* FacebookManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82448431A8F183400B540A4 /* FacebookManager.swift */; };
@@ -54,6 +55,7 @@
 		56E4A22E13D9ADD016D461F6 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9E24BFC2BD3FDB4B7751D942 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		B807F3351AB433D300571ACB /* Tracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tracker.swift; sourceTree = "<group>"; };
+		B80D21141ABC5BEC00405EAE /* QueueManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueueManager.swift; sourceTree = "<group>"; };
 		B824483F1A8EF07700B540A4 /* Login.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Login.storyboard; sourceTree = "<group>"; };
 		B82448411A8EF16C00B540A4 /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		B82448431A8F183400B540A4 /* FacebookManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FacebookManager.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 				B8F1389B1A8A4B84002A820E /* BLEPeripheralManager.swift */,
 				B899149D1A8C1F69003E8930 /* BLECentralManager.swift */,
 				B82448431A8F183400B540A4 /* FacebookManager.swift */,
+				B80D21141ABC5BEC00405EAE /* QueueManager.swift */,
 			);
 			path = Functions;
 			sourceTree = "<group>";
@@ -446,6 +449,7 @@
 				B8D9B2561A82523400B30271 /* UIViewControllerExtension.swift in Sources */,
 				B8F1389F1A8A4D13002A820E /* RoundedCornersView.swift in Sources */,
 				B8D9B2611A8255DD00B30271 /* UIImage+ImageEffects.m in Sources */,
+				B80D21151ABC5BEC00405EAE /* QueueManager.swift in Sources */,
 				B824484C1A90441600B540A4 /* ProfileViewController.swift in Sources */,
 				B82448571A9824AF00B540A4 /* GlobalData.swift in Sources */,
 				B899149E1A8C1F69003E8930 /* BLECentralManager.swift in Sources */,

--- a/bang.xcodeproj/project.pbxproj
+++ b/bang.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		B8DD29871A8B13840024ABD0 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8DD29861A8B13840024ABD0 /* CoreBluetooth.framework */; };
 		B8DD298A1A8B154E0024ABD0 /* BLEConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DD29891A8B154E0024ABD0 /* BLEConfig.swift */; };
 		B8DD298C1A8B1CC10024ABD0 /* BLEEnumExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DD298B1A8B1CC10024ABD0 /* BLEEnumExtension.swift */; };
+		B8E6D9A71ABE46B00094D582 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8E6D9A61ABE46B00094D582 /* CoreLocation.framework */; };
+		B8E6D9A91ABE55840094D582 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E6D9A81ABE55840094D582 /* LocationManager.swift */; };
 		B8EA20FA1A99D35E00BD0164 /* Contact.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B8EA20F91A99D35E00BD0164 /* Contact.storyboard */; };
 		B8EA20FC1A99D37700BD0164 /* ContactViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EA20FB1A99D37700BD0164 /* ContactViewController.swift */; };
 		B8F1389C1A8A4B84002A820E /* BLEPeripheralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F1389B1A8A4B84002A820E /* BLEPeripheralManager.swift */; };
@@ -79,6 +81,8 @@
 		B8DD29861A8B13840024ABD0 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = System/Library/Frameworks/CoreBluetooth.framework; sourceTree = SDKROOT; };
 		B8DD29891A8B154E0024ABD0 /* BLEConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BLEConfig.swift; sourceTree = "<group>"; };
 		B8DD298B1A8B1CC10024ABD0 /* BLEEnumExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BLEEnumExtension.swift; sourceTree = "<group>"; };
+		B8E6D9A61ABE46B00094D582 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
+		B8E6D9A81ABE55840094D582 /* LocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		B8EA20F91A99D35E00BD0164 /* Contact.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Contact.storyboard; sourceTree = "<group>"; };
 		B8EA20FB1A99D37700BD0164 /* ContactViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactViewController.swift; sourceTree = "<group>"; };
 		B8F1389B1A8A4B84002A820E /* BLEPeripheralManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BLEPeripheralManager.swift; sourceTree = "<group>"; };
@@ -98,6 +102,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B8E6D9A71ABE46B00094D582 /* CoreLocation.framework in Frameworks */,
 				B8DD29871A8B13840024ABD0 /* CoreBluetooth.framework in Frameworks */,
 				6A604A32C528F8BB43AD4344 /* libPods.a in Frameworks */,
 			);
@@ -125,6 +130,7 @@
 		2ABF3CDD21B556A72AAEB1C7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				B8E6D9A61ABE46B00094D582 /* CoreLocation.framework */,
 				B8DD29861A8B13840024ABD0 /* CoreBluetooth.framework */,
 				56E4A22E13D9ADD016D461F6 /* libPods.a */,
 			);
@@ -232,6 +238,7 @@
 				B899149D1A8C1F69003E8930 /* BLECentralManager.swift */,
 				B82448431A8F183400B540A4 /* FacebookManager.swift */,
 				B80D21141ABC5BEC00405EAE /* QueueManager.swift */,
+				B8E6D9A81ABE55840094D582 /* LocationManager.swift */,
 			);
 			path = Functions;
 			sourceTree = "<group>";
@@ -457,6 +464,7 @@
 				B830CDDA1A82403B0038CAFE /* SearchViewController.swift in Sources */,
 				B8FDC5131A818EDC00D4511E /* AppDelegate.swift in Sources */,
 				B807F3361AB433D300571ACB /* Tracker.swift in Sources */,
+				B8E6D9A91ABE55840094D582 /* LocationManager.swift in Sources */,
 				B8F1389C1A8A4B84002A820E /* BLEPeripheralManager.swift in Sources */,
 				B8D9B2501A824DC700B30271 /* BaseViewController.swift in Sources */,
 				B8DD298C1A8B1CC10024ABD0 /* BLEEnumExtension.swift in Sources */,

--- a/bang/Info.plist
+++ b/bang/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>This app will use your location information.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -45,6 +47,7 @@
 	<array>
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
+		<string>location</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/bang/Scripts/AppDelegate.swift
+++ b/bang/Scripts/AppDelegate.swift
@@ -12,7 +12,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-
+    var facebookManager: FacebookManager = FacebookManager.sharedInstance
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
@@ -20,13 +20,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Logs 'install' and 'app activate' App Events.
         FBAppEvents.activateApp()
 
-        if FacebookManager.sharedInstance.openFacebookSessionIfStateCreatedTokenLoaded() {
-            var profileViewController = ProfileViewController.build()
-            self.showViewController(profileViewController)
-        } else {
-            var loginViewController = LoginViewController.build()
-            self.showViewController(loginViewController)
-        }
+        facebookManager.delegate = self
+        moveToProperViewControllerByLoginState(facebookManager.openFacebookSessionIfStateCreatedTokenLoaded())
 
         return true
     }
@@ -63,8 +58,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 }
 
+extension AppDelegate: FacebookManagerDelegate {
+    func handlerFacebookSessionStateChanged(isLogined: Bool) {
+        moveToProperViewControllerByLoginState(isLogined)
+    }
+}
+
 // MARK: - Private functions
 extension AppDelegate {
+    private func moveToProperViewControllerByLoginState(isLogined: Bool) {
+        if isLogined {
+            var profileViewController = ProfileViewController.build()
+            self.showViewController(profileViewController)
+        } else {
+            var loginViewController = LoginViewController.build()
+            self.showViewController(loginViewController)
+        }
+    }
+
     private func showViewController(viewController: UIViewController) {
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
         self.window!.rootViewController = viewController;

--- a/bang/Scripts/AppDelegate.swift
+++ b/bang/Scripts/AppDelegate.swift
@@ -12,8 +12,9 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    var facebookManager: FacebookManager = FacebookManager.sharedInstance
-    var peripheralManager: BLEPeripheralManager = BLEPeripheralManager.sharedInstance
+    var facebookManager = FacebookManager.sharedInstance
+    var peripheralManager = BLEPeripheralManager.sharedInstance
+    var locationManager = LocationManager()
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
@@ -25,6 +26,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         moveToProperViewControllerByLoginState(facebookManager.openFacebookSessionIfStateCreatedTokenLoaded())
 
         // TODO : - BLEが有効かどうか判定有効でなければViewをかぶせるように修正
+        // TODO : - CoreLocationが有効でなければViewをかぶせるように修正
+
+        locationManager.setUpSignificantChangeUpdates()
+        locationManager.delegate = self
+        if LocationManager.canUseLocationService() {
+            locationManager.startLocationUpdates()
+        }
 
         return true
     }
@@ -61,9 +69,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 }
 
+// MARK: - FacebookManagerDelegate
 extension AppDelegate: FacebookManagerDelegate {
     func handlerFacebookSessionStateChanged(isLogined: Bool) {
         moveToProperViewControllerByLoginState(isLogined)
+    }
+}
+
+// MARK: - LocationManagerDelegate
+extension AppDelegate: LocationManagerDelegate {
+    func didUpdateLocation(location: CLLocation) {
+        // TODO: - APIでユーザーのローケーションを更新
+        Tracker.sharedInstance.debug("didUpdateLocation: \(location.coordinate.latitude) \(location.coordinate.longitude)")
     }
 }
 

--- a/bang/Scripts/AppDelegate.swift
+++ b/bang/Scripts/AppDelegate.swift
@@ -25,14 +25,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         facebookManager.delegate = self
         moveToProperViewControllerByLoginState(facebookManager.openFacebookSessionIfStateCreatedTokenLoaded())
 
-        // TODO : - BLEが有効かどうか判定有効でなければViewをかぶせるように修正
-        // TODO : - CoreLocationが有効でなければViewをかぶせるように修正
+        // TODO : - BLEが有効かどうか判定有効でなければ設定変更を促すViewをかぶせる
+        // TODO : - CoreLocationのstatusがAuthorizedAlwaysでない時は設定変更を促すViewをかぶせる
 
         locationManager.setUpSignificantChangeUpdates()
         locationManager.delegate = self
-        if LocationManager.canUseLocationService() {
-            locationManager.startLocationUpdates()
-        }
+        locationManager.startLocationUpdates()
 
         return true
     }

--- a/bang/Scripts/AppDelegate.swift
+++ b/bang/Scripts/AppDelegate.swift
@@ -13,6 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
     var facebookManager: FacebookManager = FacebookManager.sharedInstance
+    var peripheralManager: BLEPeripheralManager = BLEPeripheralManager.sharedInstance
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
@@ -22,6 +23,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         facebookManager.delegate = self
         moveToProperViewControllerByLoginState(facebookManager.openFacebookSessionIfStateCreatedTokenLoaded())
+
+        // TODO : - BLEが有効かどうか判定有効でなければViewをかぶせるように修正
 
         return true
     }

--- a/bang/Scripts/Configs/BLEConfig.swift
+++ b/bang/Scripts/Configs/BLEConfig.swift
@@ -10,5 +10,6 @@ import Foundation
 import CoreBluetooth
 
 // generate by "$ uuidgen" command
-let BLEServiceUUID = CBUUID(string: "8AA35DCE-F3AB-4B1D-8C23-602D1DCBDC12")
-let BLECharacteristicUUID = CBUUID(string: "D6994B86-0CC7-4188-BBFA-D61EBF234B7B")
+let kBLEServiceUUID = CBUUID(string: "8AA35DCE-F3AB-4B1D-8C23-602D1DCBDC12")
+let kBLECharacteristicUUID = CBUUID(string: "D6994B86-0CC7-4188-BBFA-D61EBF234B7B")
+let kBLECentralScaningTime: Int = 5

--- a/bang/Scripts/Configs/FacebookConfig.swift
+++ b/bang/Scripts/Configs/FacebookConfig.swift
@@ -8,4 +8,4 @@
 
 import Foundation
 
-let FBReadPermissions: [String] = ["public_profile", "email", "user_friends"]
+let kFBReadPermissions: [String] = ["public_profile", "email", "user_friends"]

--- a/bang/Scripts/Configs/LocationConfig.swift
+++ b/bang/Scripts/Configs/LocationConfig.swift
@@ -1,0 +1,13 @@
+//
+//  LocationConfig.swift
+//  bang
+//
+//  Created by Yoshikazu Oda on 2015/03/22.
+//  Copyright (c) 2015年 Yoshikazu Oda. All rights reserved.
+//
+
+import Foundation
+
+let kLocationDistance: CLLocationDistance = 3.0
+let kLocationAdoptableTimeInterval: NSTimeInterval = 15.0
+let kLocationAdoptableAccuracy: CLLocationAccuracy = 100.0

--- a/bang/Scripts/Functions/BLECentralManager.swift
+++ b/bang/Scripts/Functions/BLECentralManager.swift
@@ -9,6 +9,11 @@
 import Foundation
 import CoreBluetooth
 
+protocol BLECentralManagerDelegate {
+    func readyForScan()
+    func notReadyForScan()
+}
+
 class BLECentralManager: NSObject {
 
     class var sharedInstance: BLECentralManager {
@@ -17,6 +22,8 @@ class BLECentralManager: NSObject {
         }
         return Static.instance
     }
+
+    var delegate: BLECentralManagerDelegate?
 
     private var centralManager: CBCentralManager!
     private var peripheralContainer: [CBPeripheral] = []
@@ -45,8 +52,11 @@ extension BLECentralManager: CBCentralManagerDelegate {
         switch central.state {
         case .PoweredOn:
             canScanning = true
+            delegate?.readyForScan()
         default:
             println("state: \(central.state)")
+            canScanning = false
+            delegate?.notReadyForScan()
         }
     }
 

--- a/bang/Scripts/Functions/BLECentralManager.swift
+++ b/bang/Scripts/Functions/BLECentralManager.swift
@@ -54,7 +54,7 @@ extension BLECentralManager: CBCentralManagerDelegate {
             canScanning = true
             delegate?.readyForScan()
         default:
-            println("state: \(central.state)")
+            Tracker.sharedInstance.debug("state: \(central.state)")
             canScanning = false
             delegate?.notReadyForScan()
         }
@@ -68,7 +68,7 @@ extension BLECentralManager: CBCentralManagerDelegate {
         RSSI: NSNumber!)
     {
         if (find(peripheralContainer, peripheral) != nil) {
-            println("we´re allready connected to \(peripheral)")
+            Tracker.sharedInstance.debug("we´re allready connected to \(peripheral)")
         } else {
             peripheralContainer.append(peripheral)
             central.connectPeripheral(peripheral, options: nil)
@@ -77,19 +77,19 @@ extension BLECentralManager: CBCentralManagerDelegate {
 
     // Peripheralへの接続が失敗すると呼ばれる
     func centralManager(central: CBCentralManager!, didFailToConnectPeripheral peripheral: CBPeripheral!, error: NSError!){
-        println("didFailToConnectPeripheral \(peripheral) error:\(error)")
+        Tracker.sharedInstance.debug("didFailToConnectPeripheral \(peripheral) error:\(error)")
         removeFromPeripheralContainer(peripheral)
     }
 
     // Peripheralとの既存の接続が切断した時
     func centralManager(central: CBCentralManager!, didDisconnectPeripheral peripheral: CBPeripheral!, error: NSError!){
-        println("didDisconnectPeripheral \(peripheral) error:\(error)")
+        Tracker.sharedInstance.debug("didDisconnectPeripheral \(peripheral) error:\(error)")
         removeFromPeripheralContainer(peripheral)
     }
 
     // Peripheralと接続ができた時に呼ばれる
     func centralManager(central: CBCentralManager!, didConnectPeripheral peripheral: CBPeripheral!) {
-        println("didConnectPeripheral " + peripheral.name)
+        Tracker.sharedInstance.debug("didConnectPeripheral " + peripheral.name)
         peripheral.delegate = self
         peripheral.discoverServices([BLEServiceUUID])
     }
@@ -101,11 +101,11 @@ extension BLECentralManager: CBPeripheralDelegate {
     // PeripheralのServiceが見つかったら呼ばれる
     func peripheral(peripheral: CBPeripheral!, didDiscoverServices error: NSError!) {
         if error != nil {
-            println("error: \(error)")
+            Tracker.sharedInstance.debug("error: \(error)")
             return
         }
         if peripheral.services.count == 0 {
-            println("didDiscoverServices no services")
+            Tracker.sharedInstance.debug("didDiscoverServices no services")
             return
         }
         for service: CBService in peripheral.services as [CBService]!  {
@@ -117,11 +117,11 @@ extension BLECentralManager: CBPeripheralDelegate {
     // PeripheralServiceからCharacteristicsが見つかったら呼ばれる
     func peripheral(peripheral: CBPeripheral!, didDiscoverCharacteristicsForService service: CBService!, error: NSError!) {
         if error != nil {
-            println("error: \(error)")
+            Tracker.sharedInstance.debug("error: \(error)")
             return
         }
         if service.characteristics.count == 0 {
-            println("didDiscoverCharacteristicsForService no characteristics")
+            Tracker.sharedInstance.debug("didDiscoverCharacteristicsForService no characteristics")
             return
         }
         for characteristic: CBCharacteristic in service.characteristics as [CBCharacteristic]! {
@@ -135,10 +135,10 @@ extension BLECentralManager: CBPeripheralDelegate {
     // データ読み出しが完了すると呼ばれる
     func peripheral(peripheral: CBPeripheral!, didWriteValueForCharacteristic characteristic: CBCharacteristic!, error: NSError!) {
         if (error != nil) {
-            println("Failed... error: \(error)")
+            Tracker.sharedInstance.debug("Failed... error: \(error)")
             return
         }
-        println("Succeeded! service uuid: \(characteristic.service.UUID),　characteristic uuid: \(characteristic.UUID), value: \(characteristic.value)")
+        Tracker.sharedInstance.debug("Succeeded! service uuid: \(characteristic.service.UUID),　characteristic uuid: \(characteristic.UUID), value: \(characteristic.value)")
     }
 }
 

--- a/bang/Scripts/Functions/BLECentralManager.swift
+++ b/bang/Scripts/Functions/BLECentralManager.swift
@@ -44,6 +44,7 @@ class BLECentralManager: NSObject {
         if canScanning && !isScanning {
             elapsedTime = 0
             isScanning = true
+            recieveDictonaries = [NSDictionary]()
             startSearching()
             timer = NSTimer.scheduledTimerWithTimeInterval(1, target: self, selector: "checkCurrentCondition", userInfo: nil, repeats: true)
         }

--- a/bang/Scripts/Functions/BLECentralManager.swift
+++ b/bang/Scripts/Functions/BLECentralManager.swift
@@ -12,6 +12,7 @@ import CoreBluetooth
 protocol BLECentralManagerDelegate {
     func readyForScan()
     func notReadyForScan()
+    func didRecieveData(recieveDictonary: NSDictionary)
 }
 
 class BLECentralManager: NSObject {
@@ -37,10 +38,15 @@ class BLECentralManager: NSObject {
 
     func startScanning() {
         if canScanning {
-            centralManager.scanForPeripheralsWithServices([BLEServiceUUID],
-                options:[CBCentralManagerScanOptionAllowDuplicatesKey: false]
-            )
+            startSearching()
         }
+    }
+
+    func stopScaninng() {
+        for peripheral: CBPeripheral in peripheralContainer {
+            // TODO: - Disconnect peripherals
+        }
+        self.stopSearching()
     }
 }
 
@@ -152,9 +158,8 @@ extension BLECentralManager: CBPeripheralDelegate {
             if let recieveDictonary = NSJSONSerialization.JSONObjectWithData(
                 data, options: NSJSONReadingOptions.AllowFragments, error: nil) as? NSDictionary
             {
-                var id = recieveDictonary["id"] as Int
-                var name = recieveDictonary["name"] as String
-                Tracker.sharedInstance.debug("\(id) \(name)")
+                // TODO: - 一定期間たつか目標数が達したらまとめて返すように修正
+                delegate?.didRecieveData(recieveDictonary)
             }
         default:
             break
@@ -165,7 +170,10 @@ extension BLECentralManager: CBPeripheralDelegate {
 // MARK: - Private functions
 extension BLECentralManager {
     private func startSearching() {
-        centralManager.scanForPeripheralsWithServices([BLEServiceUUID], options: nil)
+        //centralManager.scanForPeripheralsWithServices([BLEServiceUUID], options: nil)
+        centralManager.scanForPeripheralsWithServices([BLEServiceUUID],
+            options:[CBCentralManagerScanOptionAllowDuplicatesKey: false]
+        )
     }
 
     private func stopSearching() {

--- a/bang/Scripts/Functions/BLEPeripheralManager.swift
+++ b/bang/Scripts/Functions/BLEPeripheralManager.swift
@@ -21,6 +21,7 @@ class BLEPeripheralManager: NSObject {
     private var peripheralManager: CBPeripheralManager!
     private var characteristic: CBMutableCharacteristic!
     private var responseDictonary = Dictionary<String, AnyObject>()
+    private var locationManager = LocationManager()
 
     override init() {
         super.init()
@@ -38,6 +39,9 @@ class BLEPeripheralManager: NSObject {
             self.responseDictonary["name"] = userData.objectForKey("name") as? String
             self.responseDictonary["id"] = userData.objectForKey("id") as? String
         })
+
+        locationManager.setUpStandardUpdates()
+        locationManager.startLocationUpdates()
     }
 
     func teardown() {
@@ -69,6 +73,8 @@ extension BLEPeripheralManager: CBPeripheralManagerDelegate {
         didReceiveReadRequest request: CBATTRequest!)
     {
         Tracker.sharedInstance.debug("didReceiveReadRequest...")
+        responseDictonary["longitude"] = locationManager.stringLongitude()
+        responseDictonary["latitude"] = locationManager.stringLatitude()
         request.value = NSJSONSerialization.dataWithJSONObject(responseDictonary, options: NSJSONWritingOptions.PrettyPrinted, error: nil)
         peripheralManager.respondToRequest(request, withResult: CBATTError.Success)
     }

--- a/bang/Scripts/Functions/BLEPeripheralManager.swift
+++ b/bang/Scripts/Functions/BLEPeripheralManager.swift
@@ -17,7 +17,7 @@ class BLEPeripheralManager: NSObject {
 
     class var sharedInstance: BLEPeripheralManager {
         struct Static {
-            static let instance: BLEPeripheralManager = BLEPeripheralManager()
+            static let instance = BLEPeripheralManager()
         }
         return Static.instance
     }
@@ -33,7 +33,7 @@ class BLEPeripheralManager: NSObject {
         // TODO: - MainThreadじゃなくて専用のthreadを用意
         peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
         characteristic = CBMutableCharacteristic(
-            type: BLECharacteristicUUID,
+            type: kBLECharacteristicUUID,
             properties: CBCharacteristicProperties.Read,
             value: nil,
             permissions: CBAttributePermissions.Readable
@@ -111,7 +111,7 @@ extension BLEPeripheralManager: CBPeripheralManagerDelegate {
         }
 
         // ServiceとCharacteristicsの登録
-        var service = CBMutableService(type:BLEServiceUUID, primary:true)
+        var service = CBMutableService(type:kBLEServiceUUID, primary:true)
         service.characteristics = [self.characteristic]
         self.peripheralManager.addService(service)
     }
@@ -131,7 +131,7 @@ extension BLEPeripheralManager {
     private func _startAdvertising() {
         self.peripheralManager?.startAdvertising([
             CBAdvertisementDataLocalNameKey: "",
-            CBAdvertisementDataServiceUUIDsKey:[BLEServiceUUID]
+            CBAdvertisementDataServiceUUIDsKey:[kBLEServiceUUID]
             ])
     }
 }

--- a/bang/Scripts/Functions/BLEPeripheralManager.swift
+++ b/bang/Scripts/Functions/BLEPeripheralManager.swift
@@ -25,10 +25,7 @@ class BLEPeripheralManager: NSObject {
     var delegate: BLEPeripheralManagerDelegate?
     private var peripheralManager: CBPeripheralManager!
     private var characteristic: CBMutableCharacteristic!
-    private var responseDictonary: Dictionary<String, AnyObject> = [
-        "id" : 12345,
-        "name" : "bang user"
-    ]
+    private var responseDictonary = Dictionary<String, AnyObject>()
 
     override init() {
         super.init()
@@ -41,6 +38,12 @@ class BLEPeripheralManager: NSObject {
             value: nil,
             permissions: CBAttributePermissions.Readable
         )
+
+        FacebookManager.sharedInstance.requestUserData({
+            [unowned self] (userData: NSDictionary) in
+            self.responseDictonary["name"] = userData.objectForKey("name") as? String
+            self.responseDictonary["id"] = userData.objectForKey("id") as? String
+        })
     }
 
     // NOTE: - テストが終わったら削除予定

--- a/bang/Scripts/Functions/BLEPeripheralManager.swift
+++ b/bang/Scripts/Functions/BLEPeripheralManager.swift
@@ -54,7 +54,7 @@ extension BLEPeripheralManager: CBPeripheralManagerDelegate {
         if error == nil {
             startAdvertising()
         } else {
-            println("サービスの追加に失敗しました")
+            Tracker.sharedInstance.debug("サービスの追加に失敗しました")
         }
     }
 
@@ -62,7 +62,7 @@ extension BLEPeripheralManager: CBPeripheralManagerDelegate {
     func peripheralManager(peripheral: CBPeripheralManager!,
         didReceiveReadRequest request: CBATTRequest!)
     {
-        println("didReceiveReadRequest")
+        Tracker.sharedInstance.debug("didReceiveReadRequest")
         var responseDictonary: Dictionary = [
             "userId" : 11111,
             "data" : "hoge"
@@ -75,24 +75,24 @@ extension BLEPeripheralManager: CBPeripheralManagerDelegate {
     func peripheralManager(peripheral: CBPeripheralManager!,
         willRestoreState dict: [NSObject : AnyObject]!)
     {
-        println("willRestoreState")
+        Tracker.sharedInstance.debug("willRestoreState")
     }
 
     // Advertiseが開始された時呼ばれる
     func peripheralManagerDidStartAdvertising(peripheral: CBPeripheralManager!, error: NSError!) {
         if error == nil {
-            println("PeripheralがAdvertisingを開始しました")
+            Tracker.sharedInstance.debug("PeripheralがAdvertisingを開始しました")
         } else {
-            println("PeripheralがAdvertisingの開始に失敗しました\(error)")
+            Tracker.sharedInstance.debug("PeripheralがAdvertisingの開始に失敗しました\(error)")
         }
     }
 
     // BLEの状態が変わった時に呼ばれる
     func peripheralManagerDidUpdateState(peripheral: CBPeripheralManager!) {
-        println("PeripheralのStateが変更されました(現在のState:\(peripheral.state.name))")
+        Tracker.sharedInstance.debug("PeripheralのStateが変更されました(現在のState:\(peripheral.state.name))")
 
         if peripheral.state != CBPeripheralManagerState.PoweredOn {
-            println("StateがPoweredOnでないため処理を終了します")
+            Tracker.sharedInstance.debug("StateがPoweredOnでないため処理を終了します")
             return;
         }
 

--- a/bang/Scripts/Functions/FacebookManager.swift
+++ b/bang/Scripts/Functions/FacebookManager.swift
@@ -95,7 +95,7 @@ extension FacebookManager {
                 }
                 else if FBErrorUtility.errorCategoryForError(error) == FBErrorCategory.UserCancelled {
                     // If the user cancelled login, do nothing
-                    println("user cancelled login.")
+                    Tracker.sharedInstance.debug("user cancelled login.")
                 }
                 else if FBErrorUtility.errorCategoryForError(error) == FBErrorCategory.AuthenticationReopenSession {
                     // Handle session closures that happen outside of the app

--- a/bang/Scripts/Functions/FacebookManager.swift
+++ b/bang/Scripts/Functions/FacebookManager.swift
@@ -16,7 +16,7 @@ class FacebookManager: NSObject {
 
     class var sharedInstance: FacebookManager {
         struct Static {
-            static let instance: FacebookManager = FacebookManager()
+            static let instance = FacebookManager()
         }
         return Static.instance
     }
@@ -29,7 +29,7 @@ class FacebookManager: NSObject {
     func openFacebookSessionIfStateCreatedTokenLoaded() -> Bool {
         if FBSession.activeSession().state == FBSessionState.CreatedTokenLoaded {
             // allowLoginUI set false. This prevents login dialog from showing
-            FBSession.openActiveSessionWithReadPermissions(FBReadPermissions, allowLoginUI: false, completionHandler: {
+            FBSession.openActiveSessionWithReadPermissions(kFBReadPermissions, allowLoginUI: false, completionHandler: {
                 (session, state, error) -> Void in
                 self.sessionStateChanged(session, state: state, error: error)
             })
@@ -42,7 +42,7 @@ class FacebookManager: NSObject {
             FBSession.activeSession().state != FBSessionState.Open &&
             FBSession.activeSession().state != FBSessionState.OpenTokenExtended
         {
-            FBSession.openActiveSessionWithReadPermissions(FBReadPermissions, allowLoginUI: true, completionHandler: {
+            FBSession.openActiveSessionWithReadPermissions(kFBReadPermissions, allowLoginUI: true, completionHandler: {
                 (session, state, error) -> Void in
                 self.sessionStateChanged(session, state: state, error: error)
             })

--- a/bang/Scripts/Functions/LocationManager.swift
+++ b/bang/Scripts/Functions/LocationManager.swift
@@ -1,0 +1,107 @@
+//
+//  LocationManager.swift
+//  bang
+//
+//  Created by Yoshikazu Oda on 2015/03/22.
+//  Copyright (c) 2015年 Yoshikazu Oda. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+protocol LocationManagerDelegate {
+    func didUpdateLocation(location: CLLocation)
+}
+
+class LocationManager: NSObject {
+
+    var delegate: LocationManagerDelegate?
+    private var location: CLLocation?
+    private var locationManager: CLLocationManager!
+    private var isSignificantChangeLocationService = false
+    private var hasSetUp = false
+    private var isUpdatingLocation = false
+
+    override init() {
+        super.init()
+
+        locationManager = CLLocationManager()
+        locationManager.delegate = self
+        locationManager.requestAlwaysAuthorization()
+    }
+
+    class func canUseLocationService() -> Bool {
+        return CLLocationManager.locationServicesEnabled()
+    }
+
+    // NOTE: - 標準位置情報サービス(Peripheral用)
+    func setUpStandardUpdates() {
+        setUpBase()
+        locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
+        locationManager.distanceFilter = 100
+    }
+
+    // NOTE: - 大幅変更位置情報サービス用(Location監視用)
+    func setUpSignificantChangeUpdates() {
+        setUpBase()
+        isSignificantChangeLocationService = true
+    }
+
+    func startLocationUpdates() {
+        if LocationManager.canUseLocationService() && hasSetUp && !isUpdatingLocation {
+            if isSignificantChangeLocationService {
+                locationManager.startMonitoringSignificantLocationChanges()
+            } else {
+                locationManager.startUpdatingLocation()
+            }
+            isUpdatingLocation = true
+        }
+    }
+
+    func stopLocationUpdates() {
+        if isUpdatingLocation {
+            if isSignificantChangeLocationService {
+                locationManager.stopMonitoringSignificantLocationChanges()
+            } else {
+                locationManager.stopUpdatingLocation()
+            }
+            isUpdatingLocation = false
+        }
+    }
+
+    func longitude() -> CLLocationDegrees? {
+        return location?.coordinate.longitude
+    }
+
+    func latitude() -> CLLocationDegrees? {
+        return location?.coordinate.latitude
+    }
+}
+
+// MARK: - CLLocationManagerDelegate
+extension LocationManager: CLLocationManagerDelegate {
+    func locationManager(manager: CLLocationManager!, didUpdateLocations locations: [AnyObject]!) {
+        var newLocation = locations.last as CLLocation
+        var howReent = newLocation.timestamp.timeIntervalSinceNow
+        if abs(howReent) < 15.0 || location == nil {
+            delegate?.didUpdateLocation(newLocation)
+            location = newLocation
+        }
+    }
+
+    func locationManager(manager: CLLocationManager!, didChangeAuthorizationStatus status: CLAuthorizationStatus) {
+        switch status {
+        case CLAuthorizationStatus.AuthorizedAlways:
+            startLocationUpdates()
+        default:
+            stopLocationUpdates()
+        }
+    }
+}
+
+// MARK: - Praivate functions
+extension LocationManager {
+    private func setUpBase() {
+        hasSetUp = true
+    }
+}

--- a/bang/Scripts/Functions/LocationManager.swift
+++ b/bang/Scripts/Functions/LocationManager.swift
@@ -69,12 +69,20 @@ class LocationManager: NSObject {
         }
     }
 
-    func longitude() -> CLLocationDegrees? {
-        return location?.coordinate.longitude
+    func stringLongitude() -> String {
+        var longitude = ""
+        if let _location = location {
+           longitude = "\(_location.coordinate.longitude)"
+        }
+        return longitude
     }
 
-    func latitude() -> CLLocationDegrees? {
-        return location?.coordinate.latitude
+    func stringLatitude() -> String {
+        var latitude = ""
+        if let _location = location {
+            latitude = "\(_location.coordinate.latitude)"
+        }
+        return latitude
     }
 }
 

--- a/bang/Scripts/Functions/QueueManager.swift
+++ b/bang/Scripts/Functions/QueueManager.swift
@@ -1,0 +1,27 @@
+//
+//  QueueManager.swift
+//  bang
+//
+//  Created by Yoshikazu Oda on 2015/03/20.
+//  Copyright (c) 2015年 Yoshikazu Oda. All rights reserved.
+//
+
+import Foundation
+
+class QueueManager: NSObject {
+
+    private struct Static {
+        static var backgroundQueueForPeripheral = dispatch_queue_create("com.bang.background.gueue.peripheral", DISPATCH_QUEUE_SERIAL)
+    }
+
+    class var sharedInstance: QueueManager {
+        struct Static {
+            static let instance = QueueManager()
+        }
+        return Static.instance
+    }
+
+    func peripheralQueue() -> dispatch_queue_t {
+        return Static.backgroundQueueForPeripheral
+    }
+}

--- a/bang/Scripts/Models/GlobalData.swift
+++ b/bang/Scripts/Models/GlobalData.swift
@@ -12,7 +12,7 @@ class GlobalData {
     
     class var sharedInstance: GlobalData {
         struct Static {
-            static let instance: GlobalData = GlobalData()
+            static let instance = GlobalData()
         }
         return Static.instance
     }

--- a/bang/Scripts/Utils/Tracker.swift
+++ b/bang/Scripts/Utils/Tracker.swift
@@ -1,0 +1,34 @@
+//
+//  Tracker.swift
+//  bang
+//
+//  Created by Yoshikazu Oda on 2015/03/14.
+//  Copyright (c) 2015年 Yoshikazu Oda. All rights reserved.
+//
+import Foundation
+
+/** TODO: -
+    Distribuionだったら表示しないとかある程度たまったらサーバーに送るなど
+    機能追加したいのでクラスにしておく。
+**/
+class Tracker {
+
+    class var sharedInstance: Tracker {
+        struct Static {
+            static let instance: Tracker = Tracker()
+        }
+        return Static.instance
+    }
+
+    func debug(message: String) {
+        println("\(message)")
+    }
+
+    func warn(message: String) {
+        println("\(message)")
+    }
+
+    func error(message: String) {
+        println("\(message)")
+    }
+}

--- a/bang/Scripts/Utils/Tracker.swift
+++ b/bang/Scripts/Utils/Tracker.swift
@@ -15,7 +15,7 @@ class Tracker {
 
     class var sharedInstance: Tracker {
         struct Static {
-            static let instance: Tracker = Tracker()
+            static let instance = Tracker()
         }
         return Static.instance
     }

--- a/bang/Scripts/ViewControllers/ContactViewController.swift
+++ b/bang/Scripts/ViewControllers/ContactViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 class ContactViewController: UIViewController {
 
     class func build() -> ContactViewController {
-        var storyboard: UIStoryboard = UIStoryboard(name: "Contact", bundle: nil)
+        var storyboard = UIStoryboard(name: "Contact", bundle: nil)
         return storyboard.instantiateInitialViewController() as ContactViewController
     }
 

--- a/bang/Scripts/ViewControllers/LoginViewController.swift
+++ b/bang/Scripts/ViewControllers/LoginViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 class LoginViewController: BaseViewController {
 
     class func build() -> LoginViewController {
-        var storyboard: UIStoryboard = UIStoryboard(name: "Login", bundle: nil)
+        var storyboard = UIStoryboard(name: "Login", bundle: nil)
         return storyboard.instantiateInitialViewController() as LoginViewController
     }
 

--- a/bang/Scripts/ViewControllers/LoginViewController.swift
+++ b/bang/Scripts/ViewControllers/LoginViewController.swift
@@ -17,7 +17,6 @@ class LoginViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        FacebookManager.sharedInstance.delegate = self
     }
 
     override func viewWillAppear(animated: Bool) {
@@ -38,16 +37,6 @@ class LoginViewController: BaseViewController {
         FacebookManager.sharedInstance.openFacebookSession()
     }
 
-}
-
-// MARK: - FacebookManagerDelegate
-extension LoginViewController: FacebookManagerDelegate {
-    func handlerFacebookSessionStateChanged(isLogined: Bool) {
-        if isLogined {
-            var viewController = ProfileViewController.build()
-            self.moveTo(viewController)
-        }
-    }
 }
 
 // MARK: - Private functions

--- a/bang/Scripts/ViewControllers/ProfileViewController.swift
+++ b/bang/Scripts/ViewControllers/ProfileViewController.swift
@@ -17,6 +17,7 @@ class ProfileViewController: BaseViewController {
 
     @IBOutlet weak var profilePictureView: FBProfilePictureView!
     @IBOutlet weak var nameLabel: UILabel!
+
     var facebookManager: FacebookManager = FacebookManager.sharedInstance
 
     override func viewDidLoad() {
@@ -52,6 +53,7 @@ class ProfileViewController: BaseViewController {
     }
 }
 
+// MARK: - FacebookManagerDelegate
 extension ProfileViewController: FacebookManagerDelegate {
     func handlerFacebookSessionStateChanged(isLogined: Bool) {
         if !isLogined {

--- a/bang/Scripts/ViewControllers/ProfileViewController.swift
+++ b/bang/Scripts/ViewControllers/ProfileViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 class ProfileViewController: BaseViewController {
 
     class func build() -> ProfileViewController {
-        var storyboard: UIStoryboard = UIStoryboard(name: "Profile", bundle: nil)
+        var storyboard = UIStoryboard(name: "Profile", bundle: nil)
         return storyboard.instantiateInitialViewController() as ProfileViewController
     }
 

--- a/bang/Scripts/ViewControllers/ProfileViewController.swift
+++ b/bang/Scripts/ViewControllers/ProfileViewController.swift
@@ -23,7 +23,6 @@ class ProfileViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        facebookManager.delegate = self
         facebookManager.requestUserData({
             [unowned self] (userData: NSDictionary) in
             self.nameLabel.text = userData.objectForKey("name") as? String
@@ -50,15 +49,5 @@ class ProfileViewController: BaseViewController {
 
     @IBAction func onClickLogoutButton(sender: UIButton) {
         FacebookManager.sharedInstance.closeFacebookSession()
-    }
-}
-
-// MARK: - FacebookManagerDelegate
-extension ProfileViewController: FacebookManagerDelegate {
-    func handlerFacebookSessionStateChanged(isLogined: Bool) {
-        if !isLogined {
-            var viewController = LoginViewController.build()
-            self.moveTo(viewController)
-        }
     }
 }

--- a/bang/Scripts/ViewControllers/SearchViewController.swift
+++ b/bang/Scripts/ViewControllers/SearchViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 class SearchViewController: BaseViewController {
 
     class func build() -> SearchViewController {
-        var storyboard: UIStoryboard = UIStoryboard(name: "Search", bundle: nil)
+        var storyboard = UIStoryboard(name: "Search", bundle: nil)
         return storyboard.instantiateInitialViewController() as SearchViewController
     }
 
@@ -79,12 +79,17 @@ extension SearchViewController: BLECentralManagerDelegate {
         swipteUpGesture.enabled = false
     }
 
-    func didRecieveData(recieveDictonary: NSDictionary) {
-        var id = recieveDictonary["id"] as? String
-        var name = recieveDictonary["name"] as? String
-        Tracker.sharedInstance.debug("\(id) \(name)")
-        label.text = "\(name)"
-        centralManager.stopScaninng()
+    func finishScaning(recieveDictonaries: [NSDictionary]) {
+        for recieveDictonary in recieveDictonaries {
+            var recieveDictonary = recieveDictonaries[0]
+            var id = recieveDictonary["id"] as? String
+            var name = recieveDictonary["name"] as? String
+            Tracker.sharedInstance.debug("\(id) \(name)")
+            label.text = "\(name)"
+        }
+        if recieveDictonaries.isEmpty {
+            label.text = "Ready For Search"
+        }
     }
 }
 

--- a/bang/Scripts/ViewControllers/SearchViewController.swift
+++ b/bang/Scripts/ViewControllers/SearchViewController.swift
@@ -16,9 +16,11 @@ class SearchViewController: BaseViewController {
     }
 
     @IBOutlet weak var label: UILabel!
+    @IBOutlet weak var locationInfoLabel: UILabel!
     @IBOutlet weak var swipteUpGesture: UISwipeGestureRecognizer!
 
     var centralManager: BLECentralManager!
+    private var locationManager = LocationManager()
     private var isAdvertising: Bool = true
 
     override func viewDidLoad() {
@@ -26,6 +28,15 @@ class SearchViewController: BaseViewController {
 
         centralManager = BLECentralManager.sharedInstance
         centralManager.delegate = self
+
+        locationManager.delegate = self
+        locationManager.setUpStandardUpdates()
+        locationManager.startLocationUpdates()
+    }
+
+    override func viewDidDisappear(animated: Bool) {
+        super.viewDidDisappear(animated)
+        locationManager.stopLocationUpdates()
     }
 
     override func didReceiveMemoryWarning() {
@@ -80,6 +91,15 @@ extension SearchViewController: BLECentralManagerDelegate {
     }
 }
 
+// TODO: - テストが終わったら削除
+extension SearchViewController: LocationManagerDelegate {
+    func didUpdateLocation(location: CLLocation) {
+        Tracker.sharedInstance.debug("didUpdateLocation: \(location.coordinate.latitude) \(location.coordinate.longitude) \(location.horizontalAccuracy)")
+        locationInfoLabel.text = "\(location.coordinate.latitude)\n\(location.coordinate.longitude)\n\(location.horizontalAccuracy)"
+    }
+}
+
 // MARK: - Private functions
 extension SearchViewController {
+
 }

--- a/bang/Scripts/ViewControllers/SearchViewController.swift
+++ b/bang/Scripts/ViewControllers/SearchViewController.swift
@@ -16,11 +16,15 @@ class SearchViewController: BaseViewController {
     }
 
     @IBOutlet weak var label: UILabel!
+    @IBOutlet weak var swipteUpGesture: UISwipeGestureRecognizer!
+
+    var centralManager: BLECentralManager!
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        centralManager = BLECentralManager.sharedInstance
+        centralManager.delegate = self
     }
 
     override func didReceiveMemoryWarning() {
@@ -46,4 +50,17 @@ class SearchViewController: BaseViewController {
         label.text = "\(rand)"
     }
 
+}
+
+// MARK: - BLECentralManagerDelegate
+extension SearchViewController: BLECentralManagerDelegate {
+    func readyForScan() {
+        label.text = "検索可能"
+        swipteUpGesture.enabled = true
+    }
+
+    func notReadyForScan() {
+        label.text = "検索準備"
+        swipteUpGesture.enabled = false
+    }
 }

--- a/bang/Scripts/ViewControllers/SearchViewController.swift
+++ b/bang/Scripts/ViewControllers/SearchViewController.swift
@@ -16,15 +16,22 @@ class SearchViewController: BaseViewController {
     }
 
     @IBOutlet weak var label: UILabel!
+    @IBOutlet weak var peripheralButton: UIButton!
     @IBOutlet weak var swipteUpGesture: UISwipeGestureRecognizer!
 
     var centralManager: BLECentralManager!
+    var peripheralManager: BLEPeripheralManager!
+    private var isAdvertising: Bool = true
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         centralManager = BLECentralManager.sharedInstance
         centralManager.delegate = self
+
+        peripheralButton.enabled = false
+        peripheralManager = BLEPeripheralManager.sharedInstance
+        peripheralManager.delegate = self
     }
 
     override func didReceiveMemoryWarning() {
@@ -45,22 +52,50 @@ class SearchViewController: BaseViewController {
         self.moveTo(contactViewController)
     }
 
-    @IBAction func swipeUp(sender: AnyObject) {
-        var rand: Int = Int(arc4random_uniform(10))
-        label.text = "\(rand)"
+    @IBAction func onClickPeripheralButton(sender: UIButton) {
+        if (isAdvertising) {
+            peripheralManager.stopAdvertising()
+        } else {
+            peripheralManager.startAdvertising()
+        }
+        togglePeripheralButton()
     }
 
+    @IBAction func swipeUp(sender: AnyObject) {
+        label.text = "Scaning..."
+        centralManager.startScanning()
+    }
 }
 
 // MARK: - BLECentralManagerDelegate
 extension SearchViewController: BLECentralManagerDelegate {
     func readyForScan() {
-        label.text = "検索可能"
+        label.text = "Ready For Search"
         swipteUpGesture.enabled = true
     }
 
     func notReadyForScan() {
-        label.text = "検索準備"
+        label.text = "Not Ready For Search"
         swipteUpGesture.enabled = false
+    }
+}
+
+extension SearchViewController: BLEPeripheralManagerDelegate {
+    func readyForAdvertise() {
+        togglePeripheralButton()
+        peripheralButton.enabled = true
+    }
+}
+
+// MARK: - Private functions
+extension SearchViewController {
+    func togglePeripheralButton() {
+        isAdvertising = !isAdvertising
+        peripheralButton.setTitle(
+            isAdvertising
+                ? "Stop Advertising"
+                : "Start Advertising"
+            , forState: UIControlState.Normal
+        )
     }
 }

--- a/bang/Scripts/ViewControllers/SearchViewController.swift
+++ b/bang/Scripts/ViewControllers/SearchViewController.swift
@@ -78,6 +78,14 @@ extension SearchViewController: BLECentralManagerDelegate {
         label.text = "Not Ready For Search"
         swipteUpGesture.enabled = false
     }
+
+    func didRecieveData(recieveDictonary: NSDictionary) {
+        var id = recieveDictonary["id"] as? String
+        var name = recieveDictonary["name"] as? String
+        Tracker.sharedInstance.debug("\(id) \(name)")
+        label.text = "\(name)"
+        centralManager.stopScaninng()
+    }
 }
 
 extension SearchViewController: BLEPeripheralManagerDelegate {

--- a/bang/Scripts/ViewControllers/SearchViewController.swift
+++ b/bang/Scripts/ViewControllers/SearchViewController.swift
@@ -69,8 +69,10 @@ extension SearchViewController: BLECentralManagerDelegate {
             var recieveDictonary = recieveDictonaries[0]
             var id = recieveDictonary["id"] as? String
             var name = recieveDictonary["name"] as? String
-            Tracker.sharedInstance.debug("\(id) \(name)")
-            label.text = "\(name)"
+            var longitude = recieveDictonary["longitude"] as? String
+            var latitude = recieveDictonary["latitude"] as? String
+            Tracker.sharedInstance.debug("\(id) \(name) \(longitude) \(latitude)")
+            label.text = "\(name)\n\(longitude)\n\(latitude)"
         }
         if recieveDictonaries.isEmpty {
             label.text = "Ready For Search"

--- a/bang/Scripts/ViewControllers/SearchViewController.swift
+++ b/bang/Scripts/ViewControllers/SearchViewController.swift
@@ -16,11 +16,9 @@ class SearchViewController: BaseViewController {
     }
 
     @IBOutlet weak var label: UILabel!
-    @IBOutlet weak var peripheralButton: UIButton!
     @IBOutlet weak var swipteUpGesture: UISwipeGestureRecognizer!
 
     var centralManager: BLECentralManager!
-    var peripheralManager: BLEPeripheralManager!
     private var isAdvertising: Bool = true
 
     override func viewDidLoad() {
@@ -28,10 +26,6 @@ class SearchViewController: BaseViewController {
 
         centralManager = BLECentralManager.sharedInstance
         centralManager.delegate = self
-
-        peripheralButton.enabled = false
-        peripheralManager = BLEPeripheralManager.sharedInstance
-        peripheralManager.delegate = self
     }
 
     override func didReceiveMemoryWarning() {
@@ -50,15 +44,6 @@ class SearchViewController: BaseViewController {
         var contactViewController = ContactViewController.build()
         contactViewController.modalTransitionStyle = UIModalTransitionStyle.FlipHorizontal
         self.moveTo(contactViewController)
-    }
-
-    @IBAction func onClickPeripheralButton(sender: UIButton) {
-        if (isAdvertising) {
-            peripheralManager.stopAdvertising()
-        } else {
-            peripheralManager.startAdvertising()
-        }
-        togglePeripheralButton()
     }
 
     @IBAction func swipeUp(sender: AnyObject) {
@@ -93,22 +78,6 @@ extension SearchViewController: BLECentralManagerDelegate {
     }
 }
 
-extension SearchViewController: BLEPeripheralManagerDelegate {
-    func readyForAdvertise() {
-        togglePeripheralButton()
-        peripheralButton.enabled = true
-    }
-}
-
 // MARK: - Private functions
 extension SearchViewController {
-    func togglePeripheralButton() {
-        isAdvertising = !isAdvertising
-        peripheralButton.setTitle(
-            isAdvertising
-                ? "Stop Advertising"
-                : "Start Advertising"
-            , forState: UIControlState.Normal
-        )
-    }
 }

--- a/bang/StoryBoards/Search.storyboard
+++ b/bang/StoryBoards/Search.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5Q6-js-Bk1">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1510" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5Q6-js-Bk1">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
         <!--Search View Controller-->
@@ -42,6 +43,17 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XTN-Jh-vhU">
+                                <rect key="frame" x="66" y="520" width="468" height="30"/>
+                                <color key="backgroundColor" red="1" green="0.2615612866" blue="0.28938198869999998" alpha="1" colorSpace="calibratedRGB"/>
+                                <state key="normal" title="Peripheral Button">
+                                    <color key="titleColor" red="0.96730981689999995" green="0.96730981689999995" blue="0.96730981689999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="onClickPeripheralButton:" destination="5Q6-js-Bk1" eventType="touchUpInside" id="pFA-9f-laY"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <gestureRecognizers/>
@@ -51,6 +63,9 @@
                             <constraint firstAttribute="trailing" secondItem="8ZO-mI-lVS" secondAttribute="trailing" id="NmQ-XQ-3Af"/>
                             <constraint firstAttribute="centerX" secondItem="rzE-AD-fK1" secondAttribute="centerX" id="RSl-9Z-KYY"/>
                             <constraint firstItem="rzE-AD-fK1" firstAttribute="leading" secondItem="F3H-n3-ibR" secondAttribute="leading" id="WTs-kG-59s"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="XTN-Jh-vhU" secondAttribute="trailing" constant="50" id="Yk3-fy-2XP"/>
+                            <constraint firstItem="55c-rS-p7M" firstAttribute="top" secondItem="XTN-Jh-vhU" secondAttribute="bottom" constant="50" id="Zqz-pW-Xhl"/>
+                            <constraint firstItem="XTN-Jh-vhU" firstAttribute="leading" secondItem="F3H-n3-ibR" secondAttribute="leadingMargin" constant="50" id="p00-iG-L7G"/>
                             <constraint firstAttribute="trailing" secondItem="rzE-AD-fK1" secondAttribute="trailing" id="qtP-t8-HLt"/>
                             <constraint firstAttribute="centerY" secondItem="rzE-AD-fK1" secondAttribute="centerY" id="u0I-bB-22Z"/>
                         </constraints>
@@ -60,6 +75,7 @@
                     </view>
                     <connections>
                         <outlet property="label" destination="rzE-AD-fK1" id="dn7-Xu-60B"/>
+                        <outlet property="peripheralButton" destination="XTN-Jh-vhU" id="AHi-gb-riW"/>
                         <outlet property="swipteUpGesture" destination="O1N-t1-m2M" id="sWK-Es-ERf"/>
                     </connections>
                 </viewController>

--- a/bang/StoryBoards/Search.storyboard
+++ b/bang/StoryBoards/Search.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1510" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5Q6-js-Bk1">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5Q6-js-Bk1">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
         <!--Search View Controller-->
@@ -43,17 +42,6 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XTN-Jh-vhU">
-                                <rect key="frame" x="66" y="520" width="468" height="30"/>
-                                <color key="backgroundColor" red="1" green="0.2615612866" blue="0.28938198869999998" alpha="1" colorSpace="calibratedRGB"/>
-                                <state key="normal" title="Peripheral Button">
-                                    <color key="titleColor" red="0.96730981689999995" green="0.96730981689999995" blue="0.96730981689999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <connections>
-                                    <action selector="onClickPeripheralButton:" destination="5Q6-js-Bk1" eventType="touchUpInside" id="pFA-9f-laY"/>
-                                </connections>
-                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <gestureRecognizers/>
@@ -63,9 +51,6 @@
                             <constraint firstAttribute="trailing" secondItem="8ZO-mI-lVS" secondAttribute="trailing" id="NmQ-XQ-3Af"/>
                             <constraint firstAttribute="centerX" secondItem="rzE-AD-fK1" secondAttribute="centerX" id="RSl-9Z-KYY"/>
                             <constraint firstItem="rzE-AD-fK1" firstAttribute="leading" secondItem="F3H-n3-ibR" secondAttribute="leading" id="WTs-kG-59s"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="XTN-Jh-vhU" secondAttribute="trailing" constant="50" id="Yk3-fy-2XP"/>
-                            <constraint firstItem="55c-rS-p7M" firstAttribute="top" secondItem="XTN-Jh-vhU" secondAttribute="bottom" constant="50" id="Zqz-pW-Xhl"/>
-                            <constraint firstItem="XTN-Jh-vhU" firstAttribute="leading" secondItem="F3H-n3-ibR" secondAttribute="leadingMargin" constant="50" id="p00-iG-L7G"/>
                             <constraint firstAttribute="trailing" secondItem="rzE-AD-fK1" secondAttribute="trailing" id="qtP-t8-HLt"/>
                             <constraint firstAttribute="centerY" secondItem="rzE-AD-fK1" secondAttribute="centerY" id="u0I-bB-22Z"/>
                         </constraints>
@@ -75,7 +60,6 @@
                     </view>
                     <connections>
                         <outlet property="label" destination="rzE-AD-fK1" id="dn7-Xu-60B"/>
-                        <outlet property="peripheralButton" destination="XTN-Jh-vhU" id="AHi-gb-riW"/>
                         <outlet property="swipteUpGesture" destination="O1N-t1-m2M" id="sWK-Es-ERf"/>
                     </connections>
                 </viewController>

--- a/bang/StoryBoards/Search.storyboard
+++ b/bang/StoryBoards/Search.storyboard
@@ -60,6 +60,7 @@
                     </view>
                     <connections>
                         <outlet property="label" destination="rzE-AD-fK1" id="dn7-Xu-60B"/>
+                        <outlet property="swipteUpGesture" destination="O1N-t1-m2M" id="sWK-Es-ERf"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="BfF-Jm-ZEv" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/bang/StoryBoards/Search.storyboard
+++ b/bang/StoryBoards/Search.storyboard
@@ -16,12 +16,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bang" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rzE-AD-fK1">
-                                <rect key="frame" x="0.0" y="290" width="600" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8ZO-mI-lVS">
                                 <rect key="frame" x="0.0" y="20" width="600" height="44"/>
                                 <constraints>
@@ -42,6 +36,15 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bang" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rzE-AD-fK1">
+                                <rect key="frame" x="0.0" y="255" width="600" height="90"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="90" id="HUE-j3-sje"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <gestureRecognizers/>

--- a/bang/StoryBoards/Search.storyboard
+++ b/bang/StoryBoards/Search.storyboard
@@ -36,13 +36,22 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bang" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rzE-AD-fK1">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bang Info" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rzE-AD-fK1">
                                 <rect key="frame" x="0.0" y="255" width="600" height="90"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="90" id="HUE-j3-sje"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Location Info" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Itj-qZ-4Cj">
+                                <rect key="frame" x="0.0" y="355" width="600" height="90"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="90" id="qvD-3Q-3SU"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.99607843139999996" green="0.26274509800000001" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -51,11 +60,14 @@
                         <constraints>
                             <constraint firstItem="8ZO-mI-lVS" firstAttribute="top" secondItem="sQR-is-Pvk" secondAttribute="bottom" id="9qn-xS-KAA"/>
                             <constraint firstItem="8ZO-mI-lVS" firstAttribute="leading" secondItem="F3H-n3-ibR" secondAttribute="leading" id="EEd-qM-Ijm"/>
+                            <constraint firstItem="Itj-qZ-4Cj" firstAttribute="top" secondItem="rzE-AD-fK1" secondAttribute="bottom" constant="10" id="Eij-bK-pEH"/>
                             <constraint firstAttribute="trailing" secondItem="8ZO-mI-lVS" secondAttribute="trailing" id="NmQ-XQ-3Af"/>
                             <constraint firstAttribute="centerX" secondItem="rzE-AD-fK1" secondAttribute="centerX" id="RSl-9Z-KYY"/>
                             <constraint firstItem="rzE-AD-fK1" firstAttribute="leading" secondItem="F3H-n3-ibR" secondAttribute="leading" id="WTs-kG-59s"/>
+                            <constraint firstAttribute="trailing" secondItem="Itj-qZ-4Cj" secondAttribute="trailing" id="ekZ-Zh-vUB"/>
                             <constraint firstAttribute="trailing" secondItem="rzE-AD-fK1" secondAttribute="trailing" id="qtP-t8-HLt"/>
                             <constraint firstAttribute="centerY" secondItem="rzE-AD-fK1" secondAttribute="centerY" id="u0I-bB-22Z"/>
+                            <constraint firstItem="Itj-qZ-4Cj" firstAttribute="leading" secondItem="F3H-n3-ibR" secondAttribute="leading" id="ww7-na-oHf"/>
                         </constraints>
                         <connections>
                             <outletCollection property="gestureRecognizers" destination="O1N-t1-m2M" appends="YES" id="UUd-sf-eWE"/>
@@ -63,6 +75,7 @@
                     </view>
                     <connections>
                         <outlet property="label" destination="rzE-AD-fK1" id="dn7-Xu-60B"/>
+                        <outlet property="locationInfoLabel" destination="Itj-qZ-4Cj" id="rYd-4K-b3g"/>
                         <outlet property="swipteUpGesture" destination="O1N-t1-m2M" id="sWK-Es-ERf"/>
                     </connections>
                 </viewController>


### PR DESCRIPTION
@shiruco 
位置情報取得に関して下記の実装をしました。
* AppDelegateで大幅変更位置情報サービスを利用して定期的に自分の位置を取得する(ここの位置情報が変更したタイミングでAPI経由でサーバー側の位置情報データをUpdate)
* Peripheralから標準位置情報サービスを利用した位置情報を取得しCentralに送る
 
注：大幅変更位置情報サービスはWi-Fi経由で位置情報を取得するため省エネなので上記はこちらを採用しています。詳しくはhttps://developer.apple.com/jp/documentation/LocationAwarenessPG.pdf

https://github.com/yoshinbo/bang-ios/pull/10
↑をマージ後にマージしてくださいmm

